### PR TITLE
Delete `Transfer-Encoding` header

### DIFF
--- a/lib/reverse_proxy/runner.ex
+++ b/lib/reverse_proxy/runner.ex
@@ -33,6 +33,9 @@ defmodule ReverseProxy.Runner do
               "x-forwarded-for",
               conn.remote_ip |> ip_to_string
             )
+            |> Plug.Conn.delete_req_header(
+              "transfer-encoding"
+            )
     method = conn.method |> String.downcase |> String.to_atom
     url = "#{conn.scheme}://#{server}#{conn.request_path}?#{conn.query_string}"
     headers = conn.req_headers


### PR DESCRIPTION
As `Plug.Conn.read_body/2` will handle a chunked body, passing the
header to the HTTP client with the non-chunked body would be a violation
of the HTTP specification.