### PR TITLE
Handle partial bodies

### DIFF
--- a/lib/reverse_proxy/runner.ex
+++ b/lib/reverse_proxy/runner.ex
@@ -36,7 +36,30 @@ defmodule ReverseProxy.Runner do
     method = conn.method |> String.downcase |> String.to_atom
     url = "#{conn.scheme}://#{server}#{conn.request_path}?#{conn.query_string}"
     headers = conn.req_headers
-    {:ok, body, _conn} = Plug.Conn.read_body(conn)
+    body = case Plug.Conn.read_body(conn) do
+      {:ok, body, _conn} ->
+        body
+      {:more, body, conn} ->
+        {:stream,
+          Stream.resource(
+            fn -> {body, conn} end,
+            fn
+              {body, conn} ->
+                {[body], conn}
+              nil ->
+                {:halt, nil}
+              conn ->
+                case Plug.Conn.read_body(conn) do
+                  {:ok, body, _conn} ->
+                    {[body], nil}
+                  {:more, body, conn} ->
+                    {[body], conn}
+                end
+            end,
+            fn _ -> end
+          )
+        }
+    end
 
     {method, url, body, headers}
   end

--- a/test/fixtures/body_length.exs
+++ b/test/fixtures/body_length.exs
@@ -1,0 +1,19 @@
+defmodule ReverseProxyTest.BodyLength do
+  def request(_method, _url, body, _headers, _opts \\ []) do
+    body_length = case body do
+      {:stream, body} ->
+        body
+        |> Enum.join("")
+        |> byte_size
+      body ->
+        body
+        |> byte_size
+    end
+
+    {:ok, %{
+      :headers => [],
+      :status_code => 200,
+      :body => "#{body_length}"
+    }}
+  end
+end

--- a/test/reverse_proxy/runner_test.exs
+++ b/test/reverse_proxy/runner_test.exs
@@ -57,6 +57,18 @@ defmodule ReverseProxy.RunnerTest do
     assert conn.resp_body == "success"
   end
 
+  test "retrieve/3 - partial body" do
+    conn =
+      conn(:post, "/", String.duplicate("_", 8_000_000 + 1))
+      |> put_req_header("content-type", "application/json")
+      |> ReverseProxy.Runner.retreive(
+           ["localhost"],
+           ReverseProxyTest.BodyLength
+         )
+
+    assert conn.resp_body == "8000001"
+  end
+
   test "retreive/3 - http - success with response headers" do
     conn = conn(:get, "/")
     headers = ReverseProxyTest.SuccessHTTP.headers


### PR DESCRIPTION
`Plug.Conn.read_body` will by default read 8,000,000 bytes. If the body is larger, it results in an error as the return signature doesn't match.

This reads 8,000,000 bytes as many times as necessary and use a stream implementation as is already the format accepted by HTTPoison. This might break with other HTTP clients but it's not really a breaking change and those would already be broken for bodies this large (and bodies below the default is not handled any differently).