### PR TITLE
Drop `Transfer-Encoding` header

### DIFF
--- a/lib/reverse_proxy/runner.ex
+++ b/lib/reverse_proxy/runner.ex
@@ -76,6 +76,7 @@ defmodule ReverseProxy.Runner do
   defp process_response({:ok, response}, conn) do
     conn
       |> put_resp_headers(response.headers)
+      |> Conn.delete_resp_header("transfer-encoding")
       |> Conn.send_resp(response.status_code, response.body)
   end
 

--- a/test/fixtures/chunked_response.exs
+++ b/test/fixtures/chunked_response.exs
@@ -1,0 +1,9 @@
+defmodule ReverseProxyTest.ChunkedResponse do
+  def request(_method, _url, _body, _headers, _opts \\ []) do
+    {:ok, %{
+      :headers => [{"transfer-encoding", "chunked"}],
+      :status_code => 200,
+      :body => ""
+    }}
+  end
+end

--- a/test/reverse_proxy/runner_test.exs
+++ b/test/reverse_proxy/runner_test.exs
@@ -69,6 +69,17 @@ defmodule ReverseProxy.RunnerTest do
     assert conn.resp_body == "8000001"
   end
 
+  test "retrieve/3 - chunked response" do
+    conn =
+      conn(:get, "/")
+      |> ReverseProxy.Runner.retreive(
+           ["localhost"],
+           ReverseProxyTest.ChunkedResponse
+         )
+
+    assert get_resp_header(conn, "transfer-encoding") == []
+  end
+
   test "retreive/3 - http - success with response headers" do
     conn = conn(:get, "/")
     headers = ReverseProxyTest.SuccessHTTP.headers


### PR DESCRIPTION
If the upstream service uses chunked encoding, it will set the `Transfer-Encoding` header. HTTPoison will decode the chunks and return the entire body but it keeps the header. This results in a violation of the HTTP specification when the response is returned.

(I apologize that I missed this in #7.)