### PR TITLE
Handle the case where the response has already been parsed with Plug.Parsers

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -25,6 +25,7 @@ defmodule ReverseProxy.Mixfile do
     [{:plug, "~> 1.2"},
      {:cowboy, "~> 1.0"},
      {:httpoison, "~> 0.9"},
+     {:poison, "~> 3.1"},
 
      {:earmark, "~> 1.0", only: :dev},
      {:ex_doc, "~> 0.14", only: :dev},

--- a/mix.lock
+++ b/mix.lock
@@ -17,7 +17,7 @@
   "mime": {:hex, :mime, "1.0.1", "05c393850524767d13a53627df71beeebb016205eb43bfbd92d14d24ec7a1b51", [:mix], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
   "plug": {:hex, :plug, "1.2.2", "cfbda521b54c92ab8ddffb173fbaabed8d8fc94bec07cd9bb58a84c1c501b0bd", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]},
-  "poison": {:hex, :poison, "3.0.0", "625ebd64d33ae2e65201c2c14d6c85c27cc8b68f2d0dd37828fde9c6920dd131", [:mix], []},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [], [], "hexpm"},
   "ranch": {:hex, :ranch, "1.2.1", "a6fb992c10f2187b46ffd17ce398ddf8a54f691b81768f9ef5f461ea7e28c762", [:make], []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:make, :rebar], []},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"}}

--- a/test/fixtures/body.exs
+++ b/test/fixtures/body.exs
@@ -1,0 +1,9 @@
+defmodule ReverseProxyTest.Body do
+  def request(_method, _url, body, _headers, _opts \\ []) do
+    {:ok, %{
+      :headers => [],
+      :status_code => 200,
+      :body => body
+    }}
+  end
+end

--- a/test/reverse_proxy/runner_test.exs
+++ b/test/reverse_proxy/runner_test.exs
@@ -69,6 +69,26 @@ defmodule ReverseProxy.RunnerTest do
     assert conn.resp_body == "8000001"
   end
 
+  def parse(conn, opts \\ []) do
+    opts = opts
+           |> Keyword.put_new(:parsers, [:json])
+           |> Keyword.put_new(:json_decoder, Poison)
+    Plug.Parsers.call(conn, Plug.Parsers.init(opts))
+  end
+
+  test "retrieve/3 - body parsed with Poison" do
+    conn =
+      conn(:post, "/", "{\"test\": \"data\"}")
+      |> put_req_header("content-type", "application/json")
+      |> parse()
+      |> ReverseProxy.Runner.retreive(
+           ["localhost"],
+           ReverseProxyTest.Body
+         )
+
+    assert conn.resp_body == "{\"test\":\"data\"}"
+  end
+
   test "retrieve/3 - chunked response" do
     conn =
       conn(:get, "/")


### PR DESCRIPTION
I think this should work with Phoenix. Tests still run and I added a test to run the response through the Plug JSON parser and make sure it generates the expected body OK.